### PR TITLE
Multiple updates for Lineage 18.1 manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # LineageOS 18.1 local_manifests
-Lineage OS 18.1 manifest for Samsung S6, S6 edge and Note 5
+Lineage OS 18.1 manifest for Samsung S6, S6 edge, S6 edge+ and Note 5
 
 Steps to build
 1. Clone Lineage 18.1 repo and setup your build environment according to the lineage documentation
@@ -12,8 +12,9 @@ Steps to build
 
 Replace codename with the device you are trying to build. Valid codenames:
 
-- zerofltexx : for the FLAT version of the S6 (G920)
-- zeroltexx: for the EDGE version of the S6 (G925)
+- zeroflte : for the FLAT version of the S6 (G920)
+- zerolte: for the STANDARD EDGE version of the S6 (G925)
+- zenlte: for the EDGE PLUS version of the S6 (G928)
 - noblelte: for the Note 5 International (N920)
   
 Replace core count with the number of CPU cores you have.

--- a/universal7420.xml
+++ b/universal7420.xml
@@ -2,25 +2,26 @@
 
 <manifest>
     <!--Device Trees-->
-    <project path="device/samsung/universal7420-common" name="samsungexynos7420/android_device_samsung_universal7420-common" remote="github" revision="lineage-18.1" />
-    <project path="device/samsung/zerofltexx" name="samsungexynos7420/android_device_samsung_zerofltexx" remote="github" revision="lineage-18.1" />
-    <project path="device/samsung/zeroltexx" name="samsungexynos7420/android_device_samsung_zeroltexx" remote="github" revision="lineage-18.1" />
-    <project path="device/samsung/noblelte" name="samsungexynos7420/android_device_samsung_noblelte" remote="github" revision="lineage-18.1" />
+    <project path="device/samsung/universal7420-common" name="samsungexynos7420/android_device_samsung_universal7420-common" remote="github" revision="lineage-18.1-unify" />
+    <project path="device/samsung/zeroflte" name="samsungexynos7420/android_device_samsung_zeroflte" remote="github" revision="lineage-18.1-unify" />
+    <project path="device/samsung/zerolte" name="samsungexynos7420/android_device_samsung_zerolte" remote="github" revision="lineage-18.1" />
+    <project path="device/samsung/zenlte" name="samsungexynos7420/android_device_samsung_zenlte" remote="github" revision="lineage-18.1" />
+    <project path="device/samsung/noblelte" name="samsungexynos7420/android_device_samsung_noblelte" remote="github" revision="lineage-18.1-unify" />
 
     <!--Kernel-->
-    <project path="kernel/samsung/universal7420" name="samsungexynos7420/android_kernel_samsung_universal7420" remote="github" revision="lineage-18.1" />
+    <project path="kernel/samsung/universal7420" name="samsungexynos7420/android_kernel_samsung_universal7420" remote="github" revision="lineage-18.1-kernfs" />
 
     <!-- Vendor folders -->
-    <project path="vendor/samsung" name="samsungexynos7420/proprietary_vendor_samsung" remote="github" revision="lineage-18.1" />
+    <project path="vendor/samsung" name="samsungexynos7420/proprietary_vendor_samsung" remote="github" revision="lineage-18.1-unify" />
 	
     <!-- Hardware -->
     <project path="hardware/samsung" name="LineageOS/android_hardware_samsung" remote="github" revision="lineage-18.1" />
     <project path="device/samsung_slsi/sepolicy" name="LineageOS/android_device_samsung_slsi_sepolicy" remote="github" revision="lineage-18.1" />
 
     <!-- SLSI Exynos BSP -->
-    <project path="hardware/samsung_slsi-linaro/exynos" name="samsungexynos7420/android_hardware_samsung_slsi-linaro_exynos" remote="github" revision="lineage-18.1" />
+    <project path="hardware/samsung_slsi-linaro/exynos" name="samsungexynos7420/android_hardware_samsung_slsi-linaro_exynos" remote="github" revision="lineage-18.1-unify" />
     <project path="hardware/samsung_slsi-linaro/exynos5" name="samsungexynos7420/android_hardware_samsung_slsi-linaro_exynos5" remote="github" revision="lineage-18.1" />
     <project path="hardware/samsung_slsi-linaro/openmax" name="samsungexynos7420/android_hardware_samsung_slsi-linaro_openmax" remote="github" revision="lineage-18.1" />
-    <project path="hardware/samsung_slsi-linaro/graphics" name="samsungexynos7420/android_hardware_samsung_slsi-linaro_graphics" remote="github" revision="lineage-18.1" />
+    <project path="hardware/samsung_slsi-linaro/graphics" name="samsungexynos7420/android_hardware_samsung_slsi-linaro_graphics" remote="github" revision="lineage-18.1-vpp" />
     <project path="hardware/samsung_slsi-linaro/config" name="samsungexynos7420/android_hardware_samsung_slsi-linaro_config" remote="github" revision="lineage-18.1" />
 </manifest>

--- a/universal7420.xml
+++ b/universal7420.xml
@@ -15,7 +15,7 @@
 	
     <!-- Hardware -->
     <project path="hardware/samsung" name="LineageOS/android_hardware_samsung" remote="github" revision="lineage-18.1" />
-    <project path="device/samsung_slsi" name="LineageOS/android_device_samsung_slsi_sepolicy" remote="github" revision="lineage-18.1" />
+    <project path="device/samsung_slsi/sepolicy" name="LineageOS/android_device_samsung_slsi_sepolicy" remote="github" revision="lineage-18.1" />
 
     <!-- SLSI Exynos BSP -->
     <project path="hardware/samsung_slsi-linaro/exynos" name="samsungexynos7420/android_hardware_samsung_slsi-linaro_exynos" remote="github" revision="lineage-18.1" />


### PR DESCRIPTION
This PR does 3 changes, these being 

- Update to unified trees
- Add zenlte (S6 Edge+) to the manifest.
- Correct device/samsung-slsi/sepolicy path, fixing a build error.